### PR TITLE
Windows callback fix

### DIFF
--- a/botogram/components.py
+++ b/botogram/components.py
@@ -50,8 +50,7 @@ class Component:
 
         self._component_id = str(uuid.uuid4())
 
-        if cls.component_name is None:
-            self.component_name = cls.__name__
+        self.component_name = str()
 
         return self
 


### PR DESCRIPTION
- Fix for issue #114.

The **hashed name** for a callback hook is generated from callback name and **component name**. 
On Unix, the default component name is `str()`; on Windows is both `''` and `'Component'` (it depends on the situation). This causes problems when the process is searching for the correct hook to process the query.
I fixed this issue by setting `component_name` to `str()` on `__new__(...)` method in `Component` class. I look forward to comments and reviews.