### PR TITLE
Fix installation documentation

### DIFF
--- a/docs/changelog/0.4.rst
+++ b/docs/changelog/0.4.rst
@@ -94,7 +94,7 @@ Bug fixes
 * Fix :py:attr:`botogram.Message.forward_from` giving wrong information with
   signed channel posts (`issue 80`_)
 
-.. _issue 80: https://github.com/pietroalbini/botogram/issues/80
+.. _issue 80: https://github.com/python-botogram/botogram/issues/80
 
 
 Deprecated features

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -77,7 +77,7 @@ something globally. In this case, you can ask your system administrator to
 execute the above command, or you can wrap the command with sudo, if you
 are allowed to do so::
 
-   $ sudo pip3 install botogram2
+   $ sudo python3 -m pip install botogram2
 
 If you installed from source, you need to use this command instead of the last
 one::

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -12,7 +12,7 @@ really easily with the `pip`_ command-line utility. Before installing it, be
 sure to have Python_ 3.4 (or a newer version), pip_, virtualenv_ and
 setuptools_ installed on your system. Then, issue the following command::
 
-   $ python3 -m pip install botogram
+   $ python3 -m pip install botogram2
 
 Perfect, botogram is now installed! Now, you can follow the
 ":ref:`tutorial`" chapter if you want to create a bot right now!
@@ -26,7 +26,7 @@ If you don't mind having some instability or bugs, and you want the latest
 features not yet released, you can clone the `botogram git repository`_,
 install `virtualenv`_, `invoke`_ and execute the installation from source::
 
-   $ git clone https://github.com/pietroalbini/botogram.git
+   $ git clone https://github.com/python-botogram/botogram.git
    $ cd botogram
    $ invoke install
 
@@ -77,7 +77,7 @@ something globally. In this case, you can ask your system administrator to
 execute the above command, or you can wrap the command with sudo, if you
 are allowed to do so::
 
-   $ sudo pip3 install botogram
+   $ sudo pip3 install botogram2
 
 If you installed from source, you need to use this command instead of the last
 one::

--- a/tasks.py
+++ b/tasks.py
@@ -53,8 +53,8 @@ PYTHON = "python3"
 PROJECT = "botogram"
 VERSION = "1.0.dev0"
 
-ISSUES = "https://github.com/pietroalbini/botogram/issues"
-COPYRIGHT = "Pietro Albini <pietro@pietroalbini.io>"
+ISSUES = "https://github.com/python-botogram/botogram/issues"
+COPYRIGHT = "The Botogram Authors <mail@botogram.dev>"
 
 
 def create_env(name, requirements=False, self=False, force=False):

--- a/website/index.html
+++ b/website/index.html
@@ -40,7 +40,7 @@ bot = botogram.create(<span class="cs">"API-KEY"</span>)
                 </div>
                 <nav>
                     <ul>
-                        <li><a href="https://github.com/pietroalbini/botogram">
+                        <li><a href="https://github.com/python-botogram/botogram">
                             Source code
                         </a></li>
                         <li><a href="/docs">


### PR DESCRIPTION
- Bump PyPi package to [botogram2](https://pypi.org/project/botogram2/);
- Fixed GitHub URLs;
- Fixed copyright notices.