### PR TITLE
Support for polls

### DIFF
--- a/botogram/bot.py
+++ b/botogram/bot.py
@@ -92,6 +92,7 @@ class Bot(frozenbot.FrozenBot):
         self.register_update_processor("edited_channel_post",
                                        messages.process_channel_post_edited)
         self.register_update_processor("callback_query", callbacks.process)
+        self.register_update_processor("poll", messages.process_poll_update)
 
         self._bot_id = str(uuid.uuid4())
 
@@ -140,6 +141,11 @@ class Bot(frozenbot.FrozenBot):
     def process_message(self, func):
         """Add a message processor hook"""
         self._main_component.add_process_message_hook(func)
+        return func
+
+    def poll_update(self, func):
+        """Add a poll update hook"""
+        self._main_component.add_poll_update_hook(func)
         return func
 
     def message_equals(self, string, ignore_case=True):

--- a/botogram/components.py
+++ b/botogram/components.py
@@ -47,6 +47,7 @@ class Component:
         self.__messages_edited_hooks = []
         self.__channel_post_hooks = []
         self.__channel_post_edited_hooks = []
+        self.__poll_update_hooks = []
 
         self._component_id = str(uuid.uuid4())
 
@@ -74,6 +75,14 @@ class Component:
 
         hook = hooks.ProcessMessageHook(func, self)
         self.__processors.append(hook)
+
+    def add_poll_update_hook(self, func):
+        """Add a poll update hook"""
+        if not callable(func):
+            raise ValueError("A poll update hook must be callable")
+
+        hook = hooks.PollUpdateHook(func, self)
+        self.__poll_update_hooks.append(hook)
 
     def add_message_equals_hook(self, string, func, ignore_case=True):
         """Add a message equals hook"""
@@ -220,6 +229,7 @@ class Component:
         ]
         return {
             "messages": messages,
+            "poll_updates": [self.__poll_update_hooks],
             "memory_preparers": [self.__memory_preparers],
             "tasks": [self.__timers],
             "chat_unavalable_hooks": [self.__chat_unavailable_hooks],

--- a/botogram/frozenbot.py
+++ b/botogram/frozenbot.py
@@ -111,6 +111,10 @@ class FrozenBot:
         """Register a message processor hook"""
         raise FrozenBotError("Can't add hooks to a bot at runtime")
 
+    def poll_update(self, func):
+        """Register a poll update hook"""
+        raise FrozenBotError("Can't add hooks to a bot at runtime")
+
     def message_equals(self, string, ignore_case=True):
         """Add a message equals hook"""
         raise FrozenBotError("Can't add hooks to a bot at runtime")

--- a/botogram/hooks.py
+++ b/botogram/hooks.py
@@ -81,6 +81,13 @@ class ProcessMessageHook(Hook):
     pass
 
 
+class PollUpdateHook(Hook):
+    """Underlying hook for @bot.poll_update"""
+
+    def _call(self, bot, update):
+        return bot._call(self.func, self.component_id, poll=update.poll)
+
+
 class MemoryPreparerHook(Hook):
     """Underlying hook for @bot.prepare_memory"""
 

--- a/botogram/messages.py
+++ b/botogram/messages.py
@@ -81,3 +81,19 @@ def process_channel_post_edited(bot, chains, update):
 
     bot.logger.debug("No hook actually processed the #%s update." %
                      update.update_id)
+
+
+def process_poll_update(bot, chains, update):
+    """Process a poll update"""
+    for hook in chains["poll_updates"]:
+        bot.logger.debug("Processing poll update in update #%s with"
+                         "the hook %s..." % (update.update_id, hook.name))
+
+        result = hook.call(bot, update)
+        if result is True:
+            bot.logger.debug("Update %s was just processed by the %s hook." %
+                             (update.update_id, hook.name))
+            return
+
+    bot.logger.debug("No hook actually processed the #%s update." %
+                     update.update_id)

--- a/botogram/objects/messages.py
+++ b/botogram/objects/messages.py
@@ -26,6 +26,7 @@ from .. import utils
 from .chats import User, Chat
 from .media import Audio, Voice, Document, Photo, Sticker, Video, VideoNote, \
     Contact, Location, Venue
+from .polls import Poll
 
 
 _url_protocol_re = re.compile(r"^https?:\/\/|s?ftp:\/\/|mailto:", re.I)
@@ -348,6 +349,7 @@ class Message(BaseObject, mixins.MessageMixin):
         "contact": Contact,
         "location": Location,
         "venue": Venue,
+        "poll": Poll,
         "new_chat_member": User,
         "left_chat_member": User,
         "new_chat_title": str,

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -344,6 +344,16 @@ class ChatMixin:
         return self._api.call("sendContact", args, expect=_objects().Message)
 
     @_require_api
+    def send_poll(self, question, *kargs, reply_to=None, extra=None,
+                  attach=None, notify=True):
+        """Send a poll"""
+        args = self._get_call_args(reply_to, extra, attach, notify)
+        args["question"] = question
+        args["options"] = json.dumps(list(kargs))
+
+        return self._api.call("sendPoll", args, expect=_objects().Message)
+
+    @_require_api
     def delete_message(self, message):
         """Delete a message from chat"""
         if hasattr(message, "message_id"):
@@ -506,12 +516,38 @@ class MessageMixin:
         return self.chat.send_album(*args, reply_to=self, **kwargs)
 
     @_require_api
+    def reply_with_poll(self, *args, **kwargs):
+        """Reply with a poll to the current message"""
+        return self.chat.send_poll(*args, reply_to=self, **kwargs)
+
+    @_require_api
     def delete(self):
         """Delete the message"""
         return self._api.call("deleteMessage", {
             "chat_id": self.chat.id,
             "message_id": self.id,
         })
+
+    @_require_api
+    def stop_poll(self, extra=None, attach=None):
+        """Stops a poll"""
+        args = dict()
+        args["chat_id"] = self.chat.id
+        args["message_id"] = self.id
+
+        if extra is not None:
+            _deprecated_message(
+                "The extra parameter", "1.0", "use the attach parameter", -3
+            )
+            args["reply_markup"] = json.dumps(extra.serialize())
+        if attach is not None:
+            if not hasattr(attach, "_serialize_attachment"):
+                raise ValueError("%s is not an attachment" % attach)
+            args["reply_markup"] = json.dumps(attach._serialize_attachment(
+                self.chat
+            ))
+        return self._api.call("stopPoll", args,
+                              expect=_objects().Poll)
 
 
 class FileMixin:

--- a/botogram/objects/polls.py
+++ b/botogram/objects/polls.py
@@ -18,50 +18,20 @@
 #   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 #   DEALINGS IN THE SOFTWARE.
 
-# flake8: noqa
+from .base import BaseObject, multiple
 
-from .chats     import User, Chat, UserProfilePhotos, Permissions
-from .media     import PhotoSize, Photo, Audio, Voice, Document, Sticker, \
-                       Video, VideoNote, Contact, Location, Venue
-from .messages  import Message
-from .markup    import ReplyKeyboardMarkup, ReplyKeyboardHide, ForceReply
-from .polls     import Poll, PollOption
-from .updates   import Update, Updates
-from .mixins import Album
 
-__all__ = [
-    # Chats-related objects
-    "User",
-    "Chat",
-    "UserProfilePhotos",
+class PollOption(BaseObject):
+    required = {
+        "text": str,
+        "voter_count": int,
+    }
 
-    # Media-related objects
-    "PhotoSize",
-    "Photo",
-    "Audio",
-    "Voice",
-    "Document",
-    "Sticker",
-    "Video",
-    "VideoNote",
-    "Contact",
-    "Location",
-    "Venue",
-    "Album",
 
-    # Messages-related objects
-    "Message",
-
-    # Markup-related objects
-    "ReplyKeyboardMarkup",
-    "ReplyKeyboardHide",
-    "ForceReply",
-
-    # Polls-related objects
-    "Poll",
-    "PollOption",
-
-    # Updates-related objects
-    "Update",
-    "Updates",
-]
+class Poll(BaseObject):
+    required = {
+        "id": str,
+        "question": str,
+        "options": multiple(PollOption),
+        "is_closed": bool,
+    }

--- a/botogram/objects/updates.py
+++ b/botogram/objects/updates.py
@@ -22,6 +22,7 @@ from .base import BaseObject, multiple
 
 from .callbacks import CallbackQuery
 from .messages import Message
+from .polls import Poll
 
 
 class Update(BaseObject):
@@ -41,6 +42,7 @@ class Update(BaseObject):
         "channel_post": Message,
         "edited_channel_post": Message,
         "callback_query": CallbackQuery,
+        "poll": Poll,
     }
     _check_equality_ = "update_id"
 

--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -277,7 +277,7 @@ components.
 
          @bot.poll_update
          def poll_update(poll):
-             chat_id = mydb.retrieve_chat_by_poll_id(poll.id)
+             chat_id = mydb.retrieve_chat_by_poll_id(poll.id)  # Dummy method
              if poll.is_closed:
                  bot.chat(chat_id).send('Poll final results!\n%s' %
                                         '\n'.join(['%s: %s' % (o.text, str(o.voter_count)) for o in poll.options]))

--- a/docs/api/bot.rst
+++ b/docs/api/bot.rst
@@ -261,6 +261,29 @@ components.
 
       .. versionadded:: 0.4
 
+   .. py:decoratormethod:: poll_update
+
+      Functions decorated with this decorator will receive all the updates
+      about new poll states. This allows you to act when a poll sent by the bot
+      is changed (i.e. new votes) or when a poll seen by the bot is closed.
+
+      You can :ref:`request the following arguments <bot-structure-hooks-args>`
+      in the decorated functions:
+
+      * **poll**: the poll that has just changed state
+        (instance of :py:class:`~botogram.Poll`)
+
+      .. code-block:: python
+
+         @bot.poll_update
+         def poll_update(poll):
+             chat_id = mydb.retrieve_chat_by_poll_id(poll.id)
+             if poll.is_closed:
+                 bot.chat(chat_id).send('Poll final results!\n%s' %
+                                        '\n'.join(['%s: %s' % (o.text, str(o.voter_count)) for o in poll.options]))
+
+      .. versionadded:: 0.7
+
    .. py:decoratormethod:: command(name, [hidden=False, order=0])
 
       This decorator register a new command, and calls the decorated function

--- a/docs/api/components.rst
+++ b/docs/api/components.rst
@@ -216,6 +216,33 @@ about how to create them in the ":ref:`custom-components`" chapter.
 
       .. versionadded:: 0.4
 
+   .. py:method:: add_poll_update_hook(func)
+
+      All the functions provided to this method will receive all the updates
+      about new poll states. This allows you to act when a poll sent by the bot
+      is changed (i.e. new votes) or when a poll seen by the bot is closed.
+
+      You can :ref:`request the following arguments <bot-structure-hooks-args>`
+      in the decorated functions:
+
+      * **poll**: the poll that has just changed state
+        (instance of :py:class:`~botogram.Poll`)
+
+      .. code-block:: python
+
+         class PollUpdateComponent(botogram.Component):
+             component_name = "poll-update"
+
+             def __init__(self):
+                 self.add_poll_update_hook(self.trigger)
+
+             def trigger(self, poll):
+                 bot.chat(some_id_here).send("New answers to the poll. Check it out!")
+
+      :param callable func: The function you want to use.
+
+      .. versionadded:: 0.7
+
    .. py:method:: add_command(name, func, [hidden=False, order=0])
 
       This function registers a new command, and calls the provided function

--- a/docs/api/telegram.rst
+++ b/docs/api/telegram.rst
@@ -1375,7 +1375,6 @@ about its business.
       The *notify* parameter defines if your message should
       trigger the notification on the client side (yes by default).
 
-
       .. code-block:: python
         @bot.command("my_cats")
         def my_cats(chat):
@@ -1394,11 +1393,35 @@ about its business.
       :param album: The :py:class:`~botogram.Album` send to the chat
       :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to.
       :param bool notify: If you want to trigger a notification on the client
-
       :returns: The messages you sent
       :rtype: list of :py:class:`~botogram.Message`
 
       .. versionadded:: 0.6
+
+   .. py:method:: send_poll(question, *options, [reply_to=None, extra=None, attach=None, notify=True])
+
+      Send a poll to the chat. A Telegram poll is made by a question and a list of options
+      (you can specify them as arguments).
+
+      .. code-block:: python
+
+         @bot.command("latest_poll")
+         def latest_poll(chat, message, args):
+             chat.send("This is our last poll, please answer honestly!")
+             chat.send_poll("What's your favorite color?", "Red", "Green", "Blue")
+             # Or, alternate syntax:
+             chat.send_poll("What's your favorite color?", *["Red", "Green", "Blue"])
+
+      :param str question: Poll question, 1-255 characters
+      :param *str options: List of answer options, 2-10 string of 1-100 characters each
+      :param int reply_to: The ID of the :py:class:`~botogram.Message` this one is replying to
+      :param object attach: An extra thing to attach to the message
+      :param object extra: An extra reply interface object to attach
+      :param bool notify: If you want to trigger a notification on the client
+      :returns: The message you sent
+      :rtype: ~botogram.Message
+
+      .. versionadded:: 0.7
 
    .. py:method:: delete_message(message)
 
@@ -2214,13 +2237,11 @@ about its business.
 
       .. versionadded:: 0.3
 
-
    .. py:method:: reply_with_album([album=None, notify=True])
 
-      Send album to the chat. This method returns an instance of :py:class:`~botogram.Album` or sends the :py:class:`~botogram.Album` provided by the album variable.
+      Reply to this message with an album. This method returns an instance of :py:class:`~botogram.Album` or sends the :py:class:`~botogram.Album` provided by the album variable.
       The *notify* parameter defines if your message should
       trigger the notification on the client side (yes by default).
-
 
       .. code-block:: python
         @bot.command("my_cats")
@@ -2229,7 +2250,7 @@ about its business.
             album.add_photo('tiger.jpg', caption='<b>Tiger</b>, the father', syntax='HTML')
             album.add_photo(url='https://http.cat/100.jpg', caption='Simba, the cat-mother of the year!')
             album.add_photo(file_id='some file ID here', caption='...and Sassy the daughter')
-             message.reply_with_album(album)
+            message.reply_with_album(album)
 
         @bot.command("my_dogs")
         def my_dogs(message):
@@ -2238,14 +2259,57 @@ about its business.
                  album.add_photo('shilla.jpg', caption='Shilla is so jealous!')
 
       :param album: The :py:class:`~botogram.Album` send to the chat
-
       :param bool notify: If you want to trigger a notification on the client
-
       :returns: The messages you sent
       :rtype: list of :py:class:`~botogram.Message`
 
       .. versionadded:: 0.6
 
+   .. py:method:: reply_with_poll(question, *options, [extra=None, attach=None, notify=True])
+
+      Reply to this message with a poll. A Telegram poll is made by a question and a list of options
+      (you can specify them as arguments).
+
+      .. code-block:: python
+
+         @bot.command("latest_poll")
+         def latest_poll(chat, message, args):
+             chat.send("This is our last poll, please answer honestly!")
+             message.reply_with_poll("What's your favorite color?", "Red", "Green", "Blue")
+             # Or, alternate syntax:
+             message.reply_with_poll("What's your favorite color?", *["Red", "Green", "Blue"])
+
+      :param str question: Poll question, 1-255 characters
+      :param *str options: List of answer options, 2-10 string of 1-100 characters each
+      :param object attach: An extra thing to attach to the message
+      :param object extra: An extra reply interface object to attach
+      :param bool notify: If you want to trigger a notification on the client
+      :returns: The message you sent
+      :rtype: ~botogram.Message
+
+      .. versionadded:: 0.7
+
+   .. py:method:: stop_poll([extra=None, attach=None])
+
+      Stop a poll sent by a bot.
+
+      .. code-block:: python
+         import time
+
+         @bot.command("quiz")
+         def latest_quiz(chat, message, args):
+             chat.send("Please answer within 10 seconds!")
+             msg = chat.send_poll("What's the capital of Italy?", "Milan", "Rome", "New York")
+             time.sleep(10)
+             poll = msg.stop_poll()
+             chat.send("{n} correct answers!".format(n=poll.options[1].voter_count))
+
+      :param object attach: An extra thing to attach to the message
+      :param object extra: An extra reply interface object to attach
+      :returns: The stopped poll with the final results
+      :rtype: ~botogram.Poll
+
+      .. versionadded:: 0.7
 
 .. py:class:: botogram.Photo
 
@@ -2700,7 +2764,6 @@ about its business.
 
 .. py:class:: botogram.Album
 
-
    This object represents an album (a group of photos and videos).
 
    .. py:method:: add_photo([path=None, url=None, file_id=None, caption=None, syntax=None])
@@ -2731,6 +2794,40 @@ about its business.
       :param str syntax: The name of the syntax used for the caption.
 
    .. versionadded:: 0.6
+
+
+.. py:class:: botogram.Poll
+
+   This class represents a poll.
+
+   .. py:attribute:: id
+
+      The unique poll string identifier.
+
+   .. py:attribute:: question
+
+      The poll question.
+
+   .. py:attribute:: options
+
+      A list of :py:class:`~botogram.PollOption` identifying the poll options.
+
+   .. py:attribute:: is_closed
+
+      A boolean indicating if the poll is closed.
+
+
+.. py:class:: botogram.PollOption
+
+   This class represents a :py:class:`~botogram.Poll` option.
+
+   .. py:attribute:: text
+
+      The poll option text.
+
+   .. py:attribute:: voter_count
+
+      Number of users that voted for this option.
 
 
 .. py:class:: botogram.Update

--- a/docs/changelog/0.7.rst
+++ b/docs/changelog/0.7.rst
@@ -1,0 +1,32 @@
+.. Copyright (c) 2015-2019 The Botogram Authors (see AUTHORS)
+   Documentation released under the MIT license (see LICENSE)
+
+===========================
+Changelog of botogram 0.7.x
+===========================
+
+Here you can find all the changes in the botogram 0.7.x releases.
+
+.. _changelog-0.7:
+
+botogram 0.7
+============
+
+*Alpha release, not yet released.*
+
+Release description not yet written.
+
+New features
+------------
+
+* Added support for polls
+
+   * New :py:class:`botogram.Poll`
+   * New :py:class:`botogram.PollOption`
+   * New method :py:meth:`botogram.Chat.send_poll`
+   * New method :py:meth:`botogram.Message.reply_with_poll`
+   * New method :py:meth:`botogram.Message.stop_poll`
+
+
+Bug fixes
+---------


### PR DESCRIPTION
Implementation of Telegram Polls, from Bot API 4.2:
- New class `botogram.Poll`
- New class `botogram.PollOption`
- New method `Chat.send_poll(...)`
- New method `Message.reply_with_poll(...)`
- New method `Message.stop_poll(...)`