### PR TITLE
WIP: Implemented support for normal keyboards

### DIFF
--- a/botogram/__init__.py
+++ b/botogram/__init__.py
@@ -35,6 +35,7 @@ from .runner import run
 from .objects import *
 from .utils import usernames_in
 from .callbacks import Buttons, ButtonsRow
+from .keyboards import Keyboard, KeyboardRow
 
 
 # This code will simulate the Windows' multiprocessing behavior if the

--- a/botogram/keyboards.py
+++ b/botogram/keyboards.py
@@ -1,0 +1,86 @@
+# Copyright (c) 2015-2019 The Botogram Authors (see AUTHORS)
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+#   The above copyright notice and this permission notice shall be included in
+#   all copies or substantial portions of the Software.
+#
+#   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+#   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+#   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+#   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+#   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+#   FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+
+
+
+class KeyboardRow:
+    """A row of a keyboard"""
+
+    def __init__(self):
+        self._content = []
+
+    def text(self, text):
+        """Sends a message when the button is pressed"""
+        self._content.append({"text": text})
+
+    def request_contact(self, label):
+        """Ask the user if he wants to share his contact"""
+
+        self._content.append({
+            "text": label,
+            "request_contact": True,
+        })
+
+    def request_location(self, label):
+        """Ask the user if he wants to share his location"""
+
+        self._content.append({
+            "text": label,
+            "request_location": True,
+        })
+
+    def _get_content(self, chat):
+        """Get the content of this row"""
+        for item in self._content:
+            new = item.copy()
+
+            # Replace any callable with its value
+            # This allows to dynamically generate field values
+            for key, value in new.items():
+                if callable(value):
+                    new[key] = value(chat)
+
+            yield new
+
+
+class Keyboard:
+    """Factory for keyboards"""
+
+    def __init__(self, resize=False, one_time=False, selective=False):
+        self.resize_keyboard = resize
+        self.one_time_keyboard = one_time
+        self.selective = selective
+        self._rows = {}
+
+    def __getitem__(self, index):
+        if index not in self._rows:
+            self._rows[index] = KeyboardRow()
+        return self._rows[index]
+
+    def _serialize_attachment(self, chat):
+        rows = [
+            list(row._get_content(chat)) for i, row in sorted(
+                tuple(self._rows.items()), key=lambda i: i[0]
+            )
+        ]
+
+        return {"keyboard": rows, "resize_keyboard": self.resize_keyboard,
+                "one_time_keyboard": self.one_time_keyboard,
+                "selective": self.selective}
+

--- a/botogram/objects/mixins.py
+++ b/botogram/objects/mixins.py
@@ -52,7 +52,8 @@ def _require_api(func):
 class ChatMixin:
     """Add some methods for chats"""
 
-    def _get_call_args(self, reply_to, extra, attach, notify):
+    def _get_call_args(self, reply_to, extra, attach, notify, remove_keyboard, 
+                       force_reply, selective):
         """Get default API call arguments"""
         # Convert instance of Message to ids in reply_to
         if hasattr(reply_to, "id"):
@@ -74,6 +75,23 @@ class ChatMixin:
             ))
         if not notify:
             args["disable_notification"] = True
+
+        if (remove_keyboard is None or force_reply is None) \
+                and selective is not None:
+                raise ValueError("The selective attribute is only usable" +
+                                 "when remove_keyboard or force_reply is True")
+
+        if remove_keyboard is not None:
+            args["reply_markup"] = json.dumps(
+                {"remove_keyboard": remove_keyboard}
+            )	
+            if selective is not None:
+                args["reply_markup"] = json.dumps({"selective": selective})	
+
+        if force_reply is not None:
+            args["reply_markup"] = json.dumps({"force_reply": force_reply})	
+            if selective is not None:
+                args["reply_markup"] = json.dumps({"selective": selective})	
 
         return args
 
@@ -97,9 +115,11 @@ class ChatMixin:
 
     @_require_api
     def send(self, message, preview=True, reply_to=None, syntax=None,
-             extra=None, attach=None, notify=True):
+             extra=None, attach=None, notify=True, remove_keyboard=None,
+             force_reply=None, selective=None):
         """Send a message"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         args["text"] = message
         args["disable_web_page_preview"] = not preview
 
@@ -112,9 +132,11 @@ class ChatMixin:
     @_require_api
     def send_photo(self, path=None, file_id=None, url=None, caption=None,
                    syntax=None, reply_to=None, extra=None, attach=None,
-                   notify=True):
+                   notify=True, remove_keyboard=None, force_reply=None,
+                   selective=None):
         """Send a photo"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         if caption is not None:
             args["caption"] = caption
             if syntax is not None:
@@ -133,10 +155,12 @@ class ChatMixin:
     @_require_api
     def send_audio(self, path=None, file_id=None, url=None, duration=None,
                    thumb=None, performer=None, title=None, reply_to=None,
-                   extra=None, attach=None, notify=True, caption=None, *,
+                   extra=None, attach=None, notify=True, remove_keyboard=None,
+                   force_reply=None, selective=None, caption=None, *,
                    syntax=None):
         """Send an audio track"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         if caption is not None:
             args["caption"] = caption
             if syntax is not None:
@@ -164,9 +188,11 @@ class ChatMixin:
     @_require_api
     def send_voice(self, path=None, file_id=None, url=None, duration=None,
                    title=None, reply_to=None, extra=None, attach=None,
-                   notify=True, caption=None, *, syntax=None):
+                   notify=True, remove_keyboard=None, force_reply=None,
+                   selective=None, caption=None, *, syntax=None):
         """Send a voice message"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         if caption is not None:
             args["caption"] = caption
             if syntax is not None:
@@ -194,9 +220,11 @@ class ChatMixin:
     def send_video(self, path=None, file_id=None, url=None,
                    duration=None, caption=None, streaming=True, thumb=None,
                    reply_to=None, extra=None, attach=None,
-                   notify=True, *, syntax=None):
+                   notify=True, remove_keyboard=None, force_reply=None,
+                   selective=None, *, syntax=None):
         """Send a video"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         args["supports_streaming"] = streaming
         if duration is not None:
             args["duration"] = duration
@@ -221,9 +249,11 @@ class ChatMixin:
     @_require_api
     def send_video_note(self, path=None, file_id=None, duration=None,
                         diameter=None, thumb=None, reply_to=None, extra=None,
-                        attach=None, notify=True):
+                        attach=None, notify=True, remove_keyboard=None,
+                        force_reply=None, selective=None):
         """Send a video note"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         if duration is not None:
             args["duration"] = duration
         if diameter is not None:
@@ -245,9 +275,11 @@ class ChatMixin:
     def send_gif(self, path=None, file_id=None, url=None, duration=None,
                  width=None, height=None, caption=None, thumb=None,
                  reply_to=None, extra=None, attach=None,
-                 notify=True, syntax=None):
+                 notify=True, remove_keyboard=None, force_reply=None,
+                 selective=None, syntax=None):
         """Send an animation"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify, 
+                                   remove_keyboard, force_reply, selective)
         if duration is not None:
             args["duration"] = duration
         if caption is not None:
@@ -275,9 +307,11 @@ class ChatMixin:
     @_require_api
     def send_file(self, path=None, file_id=None, url=None, thumb=None,
                   reply_to=None, extra=None, attach=None,
-                  notify=True, caption=None, *, syntax=None):
+                  notify=True, remove_keyboard=None, force_reply=None,
+                  selective=None, caption=None, *, syntax=None):
         """Send a generic file"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         if caption is not None:
             args["caption"] = caption
             if syntax is not None:
@@ -298,10 +332,12 @@ class ChatMixin:
 
     @_require_api
     def send_location(self, latitude, longitude, live_period=None,
-                      reply_to=None, extra=None, attach=None, notify=True):
+                      reply_to=None, extra=None, attach=None, notify=True,
+                      remove_keyboard=None, force_reply=None, selective=None):
         """Send a geographic location, set live_period to a number between 60
         and 86400 if it's a live location"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         args["latitude"] = latitude
         args["longitude"] = longitude
 
@@ -316,9 +352,10 @@ class ChatMixin:
 
     @_require_api
     def send_venue(self, latitude, longitude, title, address, foursquare=None,
-                   reply_to=None, extra=None, attach=None, notify=True):
+                   reply_to=None, extra=None, attach=None, notify=True, remove_keyboard=None, force_reply=None, selective=None):
         """Send a venue"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
         args["latitude"] = latitude
         args["longitude"] = longitude
         args["title"] = title
@@ -330,7 +367,8 @@ class ChatMixin:
 
     @_require_api
     def send_sticker(self, sticker=None, reply_to=None, extra=None,
-                     attach=None, notify=True, *,
+                     attach=None, notify=True, remove_keyboard=None,
+                     force_reply=None, selective=None, *,
                      path=None, file_id=None, url=None):
         """Send a sticker"""
         if sticker is not None:
@@ -342,7 +380,8 @@ class ChatMixin:
                 "The sticker parameter", "1.0", "use the path parameter", -3
             )
 
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify,
+                                   remove_keyboard, force_reply, selective)
 
         files = dict()
         args["sticker"], files["sticker"] = self._get_file_args(path,
@@ -356,9 +395,11 @@ class ChatMixin:
 
     @_require_api
     def send_contact(self, phone, first_name, last_name=None, *, reply_to=None,
-                     extra=None, attach=None, notify=True):
+                     extra=None, attach=None, notify=True, 
+                     remove_keyboard=None, force_reply=None, selective=None):
         """Send a contact"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify, 
+                                   remove_keyboard, force_reply, selective)
         args["phone_number"] = phone
         args["first_name"] = first_name
 
@@ -369,9 +410,11 @@ class ChatMixin:
 
     @_require_api
     def send_poll(self, question, *kargs, reply_to=None, extra=None,
-                  attach=None, notify=True):
+                  attach=None, notify=True, remove_keyboard=None, 
+                  force_reply=None, selective=None):
         """Send a poll"""
-        args = self._get_call_args(reply_to, extra, attach, notify)
+        args = self._get_call_args(reply_to, extra, attach, notify, 
+                                   remove_keyboard, force_reply, selective)
         args["question"] = question
         args["options"] = json.dumps(list(kargs))
 


### PR DESCRIPTION
I've added the support for "standard" keyboards natively.
List of things i still have to do:

- [x] Code
- [ ] Documentation
- [ ] Tests


A test code could be the following:
```
@bot.command("keyboard")
def kb(chat, message):
	kb = botogram.Keyboard(one_time=True)
	kb[0].text("Simple text")
	kb[1].request_contact("Request contact")
	kb[2].request_location("Request location")
	chat.send("Message with a standard keyboard", attach=kb)
	
@bot.command("rem")
def rem(chat, message):
	chat.send("Keyboard removed", force_reply=True, remove_keyboard=True)
```