### PR TITLE
Support for incoming inline keyboard markup in Message objects

### DIFF
--- a/botogram/objects/__init__.py
+++ b/botogram/objects/__init__.py
@@ -57,6 +57,8 @@ __all__ = [
     "ReplyKeyboardMarkup",
     "ReplyKeyboardHide",
     "ForceReply",
+    "InlineKeyboardButton",
+    "InlineKeyboardMarkup",
 
     # Polls-related objects
     "Poll",

--- a/botogram/objects/markup.py
+++ b/botogram/objects/markup.py
@@ -83,8 +83,8 @@ class InlineKeyboardButton(BaseObject):
     }
 
 
-class KeyboardMarkup(BaseObject):
-    """Telegram API representation of a keyboard markup
+class InlineKeyboardMarkup(BaseObject):
+    """Telegram API representation of a inline keyboard markup
 
     https://core.telegram.org/bots/api#inlinekeyboardmarkup
     """

--- a/botogram/objects/markup.py
+++ b/botogram/objects/markup.py
@@ -63,3 +63,32 @@ class ForceReply(BaseObject):
     optional = {
         "selective": bool,
     }
+
+
+class InlineKeyboardButton(BaseObject):
+    """Telegram API representation of a inline keyboard button
+
+    https://core.telegram.org/bots/api#inlinekeyboardbutton
+    """
+
+    required = {
+        "text": str,
+    }
+    optional = {
+        "url": str,
+        "callback_data": str,
+        "switch_inline_query": str,
+        "switch_inline_query_current_chat": str,
+        "pay": bool,
+    }
+
+
+class KeyboardMarkup(BaseObject):
+    """Telegram API representation of a keyboard markup
+
+    https://core.telegram.org/bots/api#inlinekeyboardmarkup
+    """
+
+    required = {
+        "inline_keyboard": multiple(multiple(InlineKeyboardButton)),
+    }

--- a/botogram/objects/messages.py
+++ b/botogram/objects/messages.py
@@ -24,6 +24,7 @@ from .base import BaseObject, _itself
 from . import mixins
 from .. import utils
 from .chats import User, Chat
+from .markup import KeyboardMarkup
 from .media import Audio, Voice, Document, Photo, Sticker, Video, VideoNote, \
     Animation, Contact, Location, Venue
 from .polls import Poll
@@ -365,6 +366,7 @@ class Message(BaseObject, mixins.MessageMixin):
         "migrate_from_chat_id": int,
         "pinned_message": _itself,
         "edit_date": int,
+        "reply_markup": KeyboardMarkup,
     }
     replace_keys = {
         "from": "sender",

--- a/botogram/objects/messages.py
+++ b/botogram/objects/messages.py
@@ -24,7 +24,7 @@ from .base import BaseObject, _itself
 from . import mixins
 from .. import utils
 from .chats import User, Chat
-from .markup import KeyboardMarkup
+from .markup import InlineKeyboardMarkup
 from .media import Audio, Voice, Document, Photo, Sticker, Video, VideoNote, \
     Animation, Contact, Location, Venue
 from .polls import Poll
@@ -366,7 +366,7 @@ class Message(BaseObject, mixins.MessageMixin):
         "migrate_from_chat_id": int,
         "pinned_message": _itself,
         "edit_date": int,
-        "reply_markup": KeyboardMarkup,
+        "reply_markup": InlineKeyboardMarkup,
     }
     replace_keys = {
         "from": "sender",

--- a/docs/api/telegram.rst
+++ b/docs/api/telegram.rst
@@ -100,6 +100,14 @@ about its business.
 
       .. versionadded:: 0.2
 
+   .. py:attribute:: reply_markup
+
+      This attribute contains the inline keyboard attached to the message.
+
+      It's always an instance of :py:class:`~botogram.KeyboardMarkup` class.
+
+      *This attribute can be None if it's not provided by Telegram.*
+
    .. py:method:: avatar_history()
 
       Get the user's avatar history. This returns a list of the current and all
@@ -3252,6 +3260,45 @@ about its business.
          * Those mentioned by @username in the text of the message object.
          * The sender of the original message, when the message this object
            is attached to is made in reply.
+
+      *This attribute can be None if it's not provided by Telegram.*
+
+
+.. py:class:: botogram.InlineKeyboardButton
+
+   This class represents an inline keyboard button.
+
+   .. py:attribute:: text
+
+      Label text of the button.
+
+   .. py:attribute:: url
+
+      The URL that the button is carrying.
+
+      *This attribute can be None if it's not provided by Telegram.*
+
+   .. py:attribute:: callback_data
+
+      The callback data that the button is carrying.
+
+      *This attribute can be None if it's not provided by Telegram.*
+
+   .. py:attribute:: switch_inline_query
+
+      The switch inline query parameter that the button is carrying.
+
+      *This attribute can be None if it's not provided by Telegram.*
+
+   .. py:attribute:: switch_inline_query_current_chat
+
+      The switch inline query current chat parameter that the button is carrying.
+
+      *This attribute can be None if it's not provided by Telegram.*
+
+   .. py:attribute:: pay
+
+      This attribute is `True` when the button is a pay button.
 
       *This attribute can be None if it's not provided by Telegram.*
 

--- a/docs/api/telegram.rst
+++ b/docs/api/telegram.rst
@@ -37,6 +37,8 @@ about its business.
 * :py:class:`~botogram.ReplyKeyboardMarkup`
 * :py:class:`~botogram.ReplyKeyboardHide`
 * :py:class:`~botogram.ForceReply`
+* :py:class:`~botogram.InlineKeyboardButton`
+* :py:class:`~botogram.InlineKeyboardMarkup`
 
 
 .. py:class:: botogram.User
@@ -104,7 +106,7 @@ about its business.
 
       This attribute contains the inline keyboard attached to the message.
 
-      It's always an instance of :py:class:`~botogram.KeyboardMarkup` class.
+      It's always an instance of :py:class:`~botogram.InlineKeyboardMarkup` class.
 
       *This attribute can be None if it's not provided by Telegram.*
 
@@ -3302,6 +3304,19 @@ about its business.
 
       *This attribute can be None if it's not provided by Telegram.*
 
+   .. versionadded:: 0.7
+
+
+.. py:class:: botogram.InlineReplyMarkup
+
+   This class represents a keyboard markup.
+
+   .. py:attribute:: inline_keyboard
+
+      Array of button rows, each represented by an array of
+      :py:class:`~botogram.InlineKeyboardButton`.
+
+   .. versionadded:: 0.7
 
 .. _Telegram's Bot API: https://core.telegram.org/bots/api
 .. _API methods: https://core.telegram.org/bots/api#available-methods

--- a/docs/changelog/0.7.rst
+++ b/docs/changelog/0.7.rst
@@ -71,6 +71,12 @@ New features
   * New method :py:meth:`Chat.remove_photo`
   * New attribute :py:attr:`Chat.photo`
 
+* Added support for incoming messages inline reply markup
+
+  * New :py:class:`~botogram.InlineKeyboardMarkup` class
+  * New :py:class:`~botogram.InlineKeyboardButton` class
+  * New attribute :py:attr:`Message.reply_markup`
+
 Bug fixes
 ---------
 


### PR DESCRIPTION
This resolves #139 issue. 
- New `InlineKeyboardMarkup` class
- New `InlineKeyboardButton` class
- New attribute `Message.reply_markup`