### PR TITLE
Fix buildthedocs.yml

### DIFF
--- a/docs/buildthedocs.yml
+++ b/docs/buildthedocs.yml
@@ -11,7 +11,7 @@ versions:
 
   - name: "0.6"
     source:
-      provider: local
+      provider: git
       url: .
       checkout: v0.6
     directory: docs


### PR DESCRIPTION
Changed provided for 0.6 version from _local_ to _git_.