### PR TITLE
Adds support for a list of new added chat members

### DIFF
--- a/botogram/objects/messages.py
+++ b/botogram/objects/messages.py
@@ -22,7 +22,7 @@ import re
 from base64 import urlsafe_b64decode
 from struct import unpack
 
-from .base import BaseObject, _itself
+from .base import BaseObject, _itself, multiple
 from . import mixins
 from .. import utils
 from ..api import ChatUnavailableError
@@ -357,6 +357,7 @@ class Message(BaseObject, mixins.MessageMixin):
         "venue": Venue,
         "poll": Poll,
         "new_chat_member": User,
+        "new_chat_members": multiple(User),
         "left_chat_member": User,
         "new_chat_title": str,
         "new_chat_photo": Photo,


### PR DESCRIPTION
Pretty simple, but necessary change. Botogram currently returns only one new_chat_member even if multiple users were returned from a getUpdate request.